### PR TITLE
修复`abc+label@gmail.com`格式的注册邮箱不能成功激活的问题

### DIFF
--- a/controllers/mail.js
+++ b/controllers/mail.js
@@ -21,7 +21,7 @@ function send_active_mail(who,token,name,email,cb){
 	var subject = config.name + '社区帐号激活';
 	var html = '<p>您好：<p/>' +
 			   '<p>我们收到您在' + config.name + '社区的注册信息，请点击下面的链接来激活帐户：</p>' +
-			   '<a href="' + config.host + '/active_account?key=' + token + '&name=' + name + '&email=' + email + '">激活链接</a>' +
+				 '<a href="' + config.host + '/active_account?key=' + token + '&name=' + name + '&email=' + encodeURIComponent(email) + '">激活链接</a>' +
 			   '<p>若您没有在' + config.name + '社区填写过注册信息，说明有人滥用了您的电子邮箱，请删除此邮件，我们对给您造成的打扰感到抱歉。</p>' +
 			   '<p>' +config.name +'社区 谨上。</p>'
 


### PR DESCRIPTION
fixed issues-1
https://github.com/muyuan/nodeclub/issues/1
