### PR TITLE
修改发送邮件链接的时候，主机名后面多一个反斜杠

### DIFF
--- a/controllers/mail.js
+++ b/controllers/mail.js
@@ -21,7 +21,7 @@ function send_active_mail(who,token,name,email,cb){
 	var subject = config.name + '社区帐号激活';
 	var html = '<p>您好：<p/>' +
 			   '<p>我们收到您在' + config.name + '社区的注册信息，请点击下面的链接来激活帐户：</p>' +
-				 '<a href="' + config.host + '/active_account?key=' + token + '&name=' + name + '&email=' + encodeURIComponent(email) + '">激活链接</a>' +
+				 '<a href="' + config.host + 'active_account?key=' + token + '&name=' + name + '&email=' + encodeURIComponent(email) + '">激活链接</a>' +
 			   '<p>若您没有在' + config.name + '社区填写过注册信息，说明有人滥用了您的电子邮箱，请删除此邮件，我们对给您造成的打扰感到抱歉。</p>' +
 			   '<p>' +config.name +'社区 谨上。</p>'
 
@@ -42,7 +42,7 @@ function send_reset_pass_mail(who,token,name,cb){
 	var subject = config.name + '社区密码重置';
 	var html = '<p>您好：<p/>' +
 			   '<p>我们收到您在' + config.name + '社区重置密码的请求，请单击下面的链接来重置密码：</p>' +
-			   '<a href="' + config.host + '/reset_pass?key=' + token + '&name=' + name + '">重置密码链接</a>' +
+			   '<a href="' + config.host + 'reset_pass?key=' + token + '&name=' + name + '">重置密码链接</a>' +
 			   '<p>若您没有在' + config.name + '社区填写过注册信息，说明有人滥用了您的电子邮箱，请删除此邮件，我们对给您造成的打扰感到抱歉。</p>' +
 			   '<p>' + config.name +'社区 谨上。</p>'
 


### PR DESCRIPTION
在默认的config.default.js文件中的host配置名称是"http://127.0.0.1/"。发送邮件的时候的链接前面也有一个斜杠。这样就会导致链接失效。为了保证影响最小，我修改了发送激活邮件函数里的链接。
