### PR TITLE
将RSS中的markdown转为html格式

### DIFF
--- a/controllers/rss.js
+++ b/controllers/rss.js
@@ -2,6 +2,7 @@ var topic_ctrl = require('./topic');
 
 var config = require('../config').config;
 var data2xml = require('data2xml');
+var Markdown = require('node-markdown').Markdown;
 
 exports.index = function (req,res,next) {
 	if (!config.rss) {
@@ -28,7 +29,7 @@ exports.index = function (req,res,next) {
 				title: topic.title,
 				link: config.rss.link + '/topic/' + topic._id,
 				guid: config.rss.link + '/topic/' + topic._id,
-				description: topic.content,
+				description: Markdown(topic.content, true),
 				author: topic.author.name,
 				pubDate: topic.create_at.toUTCString()
 			});


### PR DESCRIPTION
rss中每个description默认为markdown格式，在rss阅读器中看起来会比较凌乱。因此将rss输出中的description转为html，改进rss订阅用户的体验
