### PR TITLE
修复回复框输入慢问题

### DIFF
--- a/views/reply/reply.html
+++ b/views/reply/reply.html
@@ -36,7 +36,7 @@
 				<div class='sep10'></div>
 				<ul class='nav nav-pills'>
 					<li class='active'><a href='#markdown-<%= indexInCollection+1 %>' data-toggle='pill'>markdown</a></li>
-					<li><a href='#preview-<%= indexInCollection+1 %>' data-toggle='pill'>预览</a></li>
+					<li><a href='#preview-<%= indexInCollection+1 %>' data-toggle='pill' onclick="prettyPrint()">预览</a></li>
 				</ul>
 				<div class='tab-content'>
 					<div class='active tab-pane' id='markdown-<%= indexInCollection+1 %>'>

--- a/views/topic/index.html
+++ b/views/topic/index.html
@@ -118,7 +118,7 @@
         <div class='tabbable'>
           <ul class='nav nav-pills'>
             <li class='active'><a href='#markdown' data-toggle='pill'>markdown</a></li>
-            <li><a href='#preview' data-toggle='pill'>预览</a></li>
+            <li><a href='#preview' data-toggle='pill' onclick="prettyPrint()">预览</a></li>
           </ul>
           <div class='tab-content'>
             <div class='tab-pane active' id='markdown'>
@@ -155,18 +155,21 @@
       var converter = new Showdown.converter();
       var editor = new Markdown.Editor(converter);
       editor.run(); 
+      /*
       editor.hooks.chain('onPreviewRefresh', function () {
         prettyPrint();
       });
-
+      */
       $('.reply2_editor').each(function() {
         var editor_id = $(this).attr('id');
         var suffix = editor_id.slice(editor_id.indexOf('-'));
         var editor = new Markdown.Editor(converter, suffix);
         editor.run();
+        /*
         editor.hooks.chain('onPreviewRefresh', function () {
           prettyPrint();
         });
+        */
       });
     }
     run_md_editor();


### PR DESCRIPTION
论坛帖子：http://cnodejs.org/topic/5049775dbcd422b4441444dd

主要问题是在编辑框中输入时会导致频繁调用prettyPrint()，当文章的回复数量多时，会导致浏览器卡。
现在改为当点“预览”按钮时再调用prettyPrint()来着色。
