### PR TITLE
a标签href注入

### DIFF
--- a/public/libs/showdown.js
+++ b/public/libs/showdown.js
@@ -189,7 +189,7 @@ this.makeHtml = function (text) {
     }
     href = wholeMatch.replace(/^http:\/\/github.com\//, "https://github.com/")
     var urlreg = /(https?|ftp|mms):\/\/([A-z0-9]+[_\-]?[A-z0-9]+\.)*[A-z0-9]+\-?[A-z0-9]+\.[A-z]{2,}(\/.*)*\/?/;
-    return "<a href='" + (urlreg.test(href)?href:"http://www.cnodejs.org") + "'>" + wholeMatch + "</a>";
+    return "<a href='" + (urlreg.test(href)?href:("http://www.cnodejs.org"+href)) + "'>" + wholeMatch + "</a>";
   });
   text = text.replace(/[a-z0-9_\-+=.]+@[a-z0-9\-]+(\.[a-z0-9-]+)+/ig, function(wholeMatch){return "<a href='mailto:" + wholeMatch + "'>" + wholeMatch + "</a>";});
 


### PR DESCRIPTION
防止a标签的href被注入，同时保证了链接本网站的绝对地址有用。
比如<a href="/user/snoopy">@snoopy</a>
