### PR TITLE
使用xss模块来过滤主题及回复内容

### DIFF
--- a/controllers/reply.js
+++ b/controllers/reply.js
@@ -195,7 +195,7 @@ function get_reply_by_id(id, cb) {
         if (err) {
           return cb(err);
         }
-        reply.content = Showdown.parse(Util.escape(str));;
+        reply.content = Util.xss(Showdown.parse(str));
         return cb(err, reply);
       });
     });
@@ -250,7 +250,7 @@ function get_replies_by_topic_id(id, cb) {
             if (err) {
               return cb(err);
             }
-            replies[i].content = Showdown.parse(Util.escape(str));
+            replies[i].content = Util.xss(Showdown.parse(str));
             proxy.emit('reply_find');
           });
         });

--- a/controllers/topic.js
+++ b/controllers/topic.js
@@ -59,7 +59,7 @@ exports.index = function (req, res, next) {
       if (err) {
         return ep.emit(err);
       }
-      topic.content = Showdown.parse(Util.escape(content));
+      topic.content = Util.xss(Showdown.parse(content));
       ep.emit('@user');
     });
   });

--- a/libs/util.js
+++ b/libs/util.js
@@ -1,3 +1,5 @@
+var xss = require('xss');
+
 exports.format_date = function (date, friendly) {
   var year = date.getFullYear();
   var month = date.getMonth() + 1;
@@ -76,4 +78,14 @@ exports.escape = function(html){
   .replace(/~0$/,'')
   .replace(/^\n\n/, '')
   .replace(/\n\n$/, '');
+};
+
+/**
+ * 过滤XSS攻击代码
+ *
+ * @param {string} html
+ * @return {string}
+ */
+exports.xss = function (html) {
+  return xss(html);
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "validator": "0.3.7",
     "ndir": ">=0.1.3",
     "nodemailer": "0.3.5",
-    "data2xml": "0.4.0"
+    "data2xml": "0.4.0",
+    "xss": ">=0.0.2"
   },
   "devDependencies": {
     "should": "*",


### PR DESCRIPTION
xss模块项目地址：https://github.com/leizongmin/js-xss

用xss()模块对markdown生成的HTML代码进行过滤，仅允许在白名单中的HTML的标签，对不在白名单中的标签会将`<>`进行转义，同时能控制仅允许指定的属性名称，如`<a>`标签仅运行属性`href`，`target`，`title`，其它属性一律去掉，而且能统一标签HTML代码的风格（如所有属性值均用双引号括起来，对属性值内的双引号进行转义）
