### PR TITLE
修正无法正确解析帖子内容中 http://127.0.0.1 这类IP地址的链接

### DIFF
--- a/public/libs/showdown.js
+++ b/public/libs/showdown.js
@@ -195,7 +195,7 @@ this.makeHtml = function (text) {
       return wholeMatch; 
     }
     href = wholeMatch.replace(/^http:\/\/github.com\//, "https://github.com/")
-    var urlreg = /(https?|ftp|mms):\/\/([A-z0-9]+[_\-]?[A-z0-9]+\.)*[A-z0-9]+\-?[A-z0-9]+\.[A-z]{2,}(\/.*)*\/?/;
+    var urlreg = /(https?|ftp|mms):\/\/((([A-z0-9]+[_\-]?[A-z0-9]+\.)*[A-z0-9]+\-?[A-z0-9]+\.[A-z]{2,})|(([0-9]{1,3}\.){3}[0-9]{1,3}))(\/.*)*\/?/;
     return "<a href='" + (urlreg.test(href)?href:("http://www.cnodejs.org"+href)) + "'>" + wholeMatch + "</a>";
   });
   text = text.replace(/[a-z0-9_\-+=.]+@[a-z0-9\-]+(\.[a-z0-9-]+)+/ig, function(wholeMatch){return "<a href='mailto:" + wholeMatch + "'>" + wholeMatch + "</a>";});


### PR DESCRIPTION
Cnodejs上有人提出这个问题：http://cnodejs.org/topic/507f72cff75c3a876235d837

另外，xss模块增加了几个如ol, blockquote这样的排版标签，需要升级一下该模块。
