### PR TITLE
#132 “setting”页面里的“个人网站”选项不支持"https://"

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -126,7 +126,7 @@ exports.setting = function (req, res, next) {
 
     if (url !== '') {
       try {
-        if (url.indexOf('http://') < 0) {
+        if ((url.indexOf('http://') < 0) && (url.indexOf('https://') < 0)) {
           url = 'http://' + url;
         }
         check(url, '不正确的个人网站。').isUrl();


### PR DESCRIPTION
增加了对"https://"的校验，基本上没有改逻辑。
就加了个&&操作符。
第一次提交pull request，可能没怎么看代码规范就交上来了。所以请大家帮忙看下。
如果哪边写的不好，我会拿回来重改。
谢谢。:octocat:

cnodejs/nodeclub#132
