### PR TITLE
调整 message 过长布局, 修复 white-space CSS

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -403,8 +403,8 @@ a.user_avatar:hover {
   line-height: 48px;
 }
 .user_action {}
-.reply_content .markdown-text {
-  margin-left: 50px;
+.reply_content {
+  padding-left: 50px;
 }
 .reply_editor {
   height: 80px;
@@ -478,7 +478,11 @@ img.unread {
   max-height: 40px;
 }
 .markdown-text {
-  /*white-space: pre;*/
+    white-space: pre-wrap;       /* CSS3 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 /* markdown editor */
 .wmd-button-bar {


### PR DESCRIPTION
- 原先消息提示有 `@` 或者回复, 标题太长时出现换行, 布局被破坏, 现在再缩小宽度
- `white-space: pre` 属性使用错误, 改换为 `white:space:pre-wrap` 效果看链接链接里
  https://github.com/cnodejs/nodeclub/commit/7abfb409dafed8d1e51847b3ca4853f7e84a0d81
