### PR TITLE
limit the length of message to 20, 限制回复列表

### DIFF
--- a/proxy/message.js
+++ b/proxy/message.js
@@ -73,7 +73,7 @@ exports.getMessageById = function (id, callback) {
  * @param {Function} callback 回调函数
  */
 exports.getMessagesByUserId = function (userId, callback) {
-  Message.find({master_id: userId}, [], {sort: [['create_at', 'desc']]}, callback);
+  Message.find({master_id: userId}, [], {sort: [['create_at', 'desc']], limit: 20}, callback);
 };
 
 /**


### PR DESCRIPTION
我个人的经验是大概一天两都都会 Check 一下, 通知数量几乎不会到两位数, 于是限定 20.
试图解决性能方面的问题, 但本地不知道怎么样详细测试, 先提交 Commit 等待线上测试或更好的方案.

related: https://github.com/cnodejs/nodeclub/issues/145
