### PR TITLE
Fix 'title' textarea layout problem.

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -496,6 +496,9 @@ img.unread {
   border-radius: 3px;
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.15);
 }
+textarea[id^=title] {
+  resize: none;
+}
 textarea[id^=wmd-input] {
   height: 200px;
 }


### PR DESCRIPTION
Originally, you can resize the #title textarea, but that can lead to serious layout problem when you resize it with a very long width. The fieldset will be stretched, then the layout will be destroyed.
