### PR TITLE
fix: `profile_image_url` isnt used in settings

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -117,7 +117,10 @@ exports.setting = function (req, res, next) {
     email = sanitize(email).xss();
     var url = sanitize(req.body.url).trim();
     url = sanitize(url).xss();
-    var profile_image_url = sanitize(sanitize(req.body.profile_image_url).trim()).xss();
+    var profile_image_url = null;
+    if (typeof req.body.profile_image_url === 'string') {
+      profile_image_url = sanitize(sanitize(req.body.profile_image_url).trim()).xss();
+    }
     var location = sanitize(req.body.location).trim();
     location = sanitize(location).xss();
     var signature = sanitize(req.body.signature).trim();
@@ -188,7 +191,9 @@ exports.setting = function (req, res, next) {
         return next(err);
       }
       user.url = url;
-      user.profile_image_url = profile_image_url;
+      if (typeof profile_image_url === 'string') {
+        user.profile_image_url = profile_image_url;
+      }
       user.location = location;
       user.signature = signature;
       user.profile = profile;


### PR DESCRIPTION
![screen shot 2014-02-27 at 12 07 14](https://f.cloud.github.com/assets/1935767/2271955/15bb4128-9f00-11e3-95d7-2ec000a2c03b.png)

我查看`POST /settings`的request的form data如下：

```
name:yorkie
email:yorkiefixer@gmail.com
url:http://yorkiefixer.me
location:Beijing, China
signature:
profile:https://github.com/yorkie
weibo:
github:yorkie
receive_at_mail:on
receive_reply_mail:on
action:change_setting
```

/cc @alsotang :)
