### PR TITLE
限制 reply h1 h2 h3 大小; 修改话题发表页面 Markdown 提示

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -674,9 +674,10 @@ textarea[id^=wmd-input] {
 .topic_content h3 {
   line-height: 160%;
 }
+.reply_area h1, .reply_area h2, .reply_area h3,
 .topic_content h1, .topic_content h2, .topic_content h3 {
   margin: 14px 0;
-  font-size: 22px;
+  font-size: 20px;
 }
 .topic_content h4,
 .topic_content h5,

--- a/views/topic/edit.html
+++ b/views/topic/edit.html
@@ -1,17 +1,22 @@
 <div id='sidebar'>
   <div class='panel'>
     <div class='header'>
-      <span class='col_fade'>话题发布步骤</span>
+      <span class='col_fade'>Markdown 语法参考</span>
     </div>
     <div class='inner'>
       <ol>
-        <li>填写标题</li>
-        <li>填写内容</li>
-        <li>选择话题标签</li>
-        <li>确认后发布话题</li>
+        <li><tt>### 单行的标题</tt></li>
+        <li><tt>**粗体**</tt></li>
+        <li><tt>`console.log('行内代码')`</tt></li>
+        <li><tt>```</tt> 包裹标记代码块</li>
+        <li><tt>```js</tt> 在开始的位置标记编程语言</li>
+        <li><tt>[内容](链接)</tt></li>
+        <li><tt>![文字说明](图片链接)</tt></li>
       </ol>
+      <span><a href='http://www.ituring.com.cn/article/775' target='_blank'>Markdown 文档</a></span>
     </div>
   </div>
+
   <div class='panel'>
     <div class='header'>
       <span class='col_fade'>话题发布指南</span>
@@ -24,23 +29,7 @@
       </ol>
     </div>
   </div>
-  <div class='panel'>
-    <div class='header'>
-      <span class='col_fade'>markdown语法参考</span>
-    </div>
-    <div class='inner'>
-      <ol>
-        <li>换行：两个空格</li>
-        <li>分段：一个空行</li>
-        <li>斜体：*斜体*</li>
-        <li>粗体：**粗体**</li>
-        <li>代码：行首四个空格</li>
-        <li>链接：[文字](url)</li>
-        <li>图片：![alt 文字](url)</li>
-      </ol>
-      <span>详见 <a href='http://www.ituring.com.cn/article/775' target='_blank'>Markdown Wiki</a></span>
-    </div>
-  </div>
+
 </div>
 
 <div id='content'>


### PR DESCRIPTION
主要是发表话题的界面, 去掉了步骤的说明, 调整了 Markdown 的文案
![screen shot 2014-03-19 at 11 10 33 pm](https://f.cloud.github.com/assets/449224/2461598/81d86a2e-af78-11e3-8624-23ad41ebb955.png)
