### PR TITLE
reply加入取消功能，限制reply有值才可回复

### DIFF
--- a/public/javascripts/markdown_editor.js
+++ b/public/javascripts/markdown_editor.js
@@ -20,6 +20,17 @@ $('.action_preview').click(function(event) {
   var $editor = $(this).parents('.markdown_editor');
   $editor.removeClass('in_editor').addClass('in_preview');
   var content = $editor.find('textarea.editor').val();
+  if (content !== '') {
+    $editor.find('div.markdown_in_preview')
+    .find('div.editor_buttons')
+    .find('button.reply2_submit_btn')
+    .removeAttr('disabled');
+  } else {
+    $editor.find('div.markdown_in_preview')
+    .find('div.editor_buttons')
+    .find('button.reply2_submit_btn')
+    .attr('disabled', 'disabled');
+  }
   var html = marked(content);
   $editor.find('.preview').html(html);
   prettyPrint();
@@ -29,4 +40,18 @@ $('.action_modify').click(function() {
   var $editor = $(this).parents('.markdown_editor');
   $editor.removeClass('in_preview').addClass('in_editor');
   $editor.find('textarea.editor').focus()
+});
+
+$('.action_cancel').click(function(event) {
+  event.preventDefault();
+  var $editor = $(this).parents('.markdown_editor');
+  var $form = $(this).parents('form.reply2_form');
+  $editor.removeClass('in_preview').addClass('in_editor');
+  $form.find('textarea.reply_editor').val('');
+  $(this).next('button.reply2_submit_btn').attr('disabled', 'disabled');
+  $editor.find('div.markdown_in_editor')
+         .find('div.editor_buttons')
+         .find('button.reply2_submit_btn')
+         .attr('disabled', 'disabled');
+  $form.hide('fast');
 });

--- a/views/reply/reply.html
+++ b/views/reply/reply.html
@@ -49,16 +49,18 @@
               id="reply2_editor_<%- reply._id %>" name='r2_content' rows='4'></textarea>
             <div class='editor_buttons'>
               <button class='btn action_preview'>预览</button>
+              <button class='btn action_cancel'>取消</button>
               <button class='btn reply2_submit_btn btn-primary'
-                type="submit" data-id='<%= reply._id %>'>回复</button>
+                type="submit" data-id='<%= reply._id %>' disabled="disabled">回复</button>
             </div>
           </div>
           <div class='markdown_in_preview'>
             <div class='preview'></div>
             <div class='editor_buttons'>
               <button class='btn action_modify'>修改</button>
+              <button class='btn action_cancel'>取消</button>
               <button class='btn reply2_submit_btn btn-primary'
-                type="submit" data-id='<%= reply._id %>'>回复</button>
+                type="submit" data-id='<%= reply._id %>' disabled="disabled">回复</button>
             </div>
           </div>
         </div>

--- a/views/topic/index.html
+++ b/views/topic/index.html
@@ -190,6 +190,9 @@
         textarea.focus();
         if (textarea.val().indexOf('@' + user) < 0) {
           textarea.val('@' + user + ' ');
+          textarea.next('div.editor_buttons').find('button.reply2_submit_btn').removeAttr('disabled');
+          textarea.parents('div.markdown_in_editor').next('div.markdown_in_preview')
+          .find('div.editor_buttons').find('button.reply2_submit_btn').removeAttr('disabled');
         }
       });
     });
@@ -271,6 +274,15 @@
       at: '@',
       data: allNames
     });
+  });
+
+  $('textarea.editor').keyup(function() {
+      var txtValue = this.value;
+      if (txtValue !== '') {
+        $(this).next('div.editor_buttons').find('button.reply2_submit_btn').removeAttr('disabled');
+      } else {
+        $(this).next('div.editor_buttons').find('button.reply2_submit_btn').attr('disabled', 'disabled');
+      }
   });
 
 </script>


### PR DESCRIPTION
1.topic下回复，加入了一个cancel按钮，用以不想回复时 取消。
2.在回复时，如果值为空，disabled回复按钮，限制不能回复。解决直接点击回复，跳转的空白页面问题，增强体验。哈哈
