### PR TITLE
ignore sublime prj files and vim temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ desktop.ini
 
 .idea
 public/upload/*
+
+*.sublime-project
+*.sublime-workspace
+*.swp


### PR DESCRIPTION
As sublime and vim are two common editors, ignore their footprints.
