### PR TITLE
fix bug: don't trim before update reply

### DIFF
--- a/controllers/reply.js
+++ b/controllers/reply.js
@@ -143,8 +143,8 @@ exports.update = function (req, res, next) {
 
     if (String(reply.author_id) === req.session.user._id.toString() || req.session.user.is_admin) {
 
-      reply.content = content.trim();
-      if (content.length > 0) {
+      if (content.trim().length > 0) {
+        reply.content = content;
         reply.save(function (err) {
           if (err) {
             return next(err);


### PR DESCRIPTION
见这个帖子 [#544bae10b379fed26548a54d](https://cnodejs.org/topic/544bae10b379fed26548a54d) 中我在 4 楼的回复。当我编辑这个回复的时候，无论如何我都没办法给第一个段落前加上 4 个空格，以便让它显示为 `pre`.

然后根据 [controllers/reply.js](https://github.com/cnodejs/nodeclub/blob/master/controllers/reply.js#L22) 22 行到 23 行的逻辑，在编辑回复时，应该检查 trim 后是否为空，但不应该保存 trim 后的结果。
