### PR TITLE
话题发布页面标题框样式调整

### DIFF
--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -764,6 +764,8 @@ textarea#title {
   width: 98%;
   border: none;
   margin-bottom: 1em;
+  resize: none;
+  height: 20px;
 }
 
 .editor_buttons {


### PR DESCRIPTION
1.  标题输入框未固定大小
2.  Chrome下标题框高度为20px，而Firefox（版本33.0.2）下为37px
