### PR TITLE
编辑器预览状态下，添加链接或图片弹出的对话框被遮挡

### DIFF
--- a/public/libs/editor/editor.css
+++ b/public/libs/editor/editor.css
@@ -406,7 +406,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
   top: 0;
   left: 100%;
   background: #f9f9f5;
-  z-index: 9999;
+  z-index: 1000;
   overflow: auto;
   -webkit-transition: left 0.2s ease;
   -moz-transition: left 0.2s ease;


### PR DESCRIPTION
修改编辑器预览div的z-index值，使其小于弹出对话框的z-index值