### PR TITLE
区分推送环境

### DIFF
--- a/common/push.js
+++ b/common/push.js
@@ -42,6 +42,7 @@ exports.send = function (type, author_id, master_id, topic_id) {
           JPush.ios(msg, null, count, null, extras),
           JPush.android(msg, null, null, extras)
         )
+        .setOptions(null, null, null, !config.debug)
         .send(function(err, res) {
           if (config.debug) {
             if (err) {


### PR DESCRIPTION
根据config.debug区分iOS推送是开发还是生产

jpush文档：http://docs.jpush.io/server/rest_api_v3_push/#platform

```
如果目标平台为 iOS 平台 需要在 options 中通过 apns_production 字段来制定推送环境。True 表示推送生产环境，False 表示要推送开发环境； 如果不指定则为推送生产环境。
```