### PR TITLE
修复长标题的行高

### DIFF
--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -48,6 +48,7 @@ body {
   display: inline-block;
   vertical-align: bottom;
   width: 75%;
+  line-height: 130%;
 }
 
 #content .changes {


### PR DESCRIPTION
修复标题太长时，换行挤到一块了