### PR TITLE
the max parameter has been deprecated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build:
 	@./node_modules/loader/bin/build views .
 
 start: install build
-	@nohup ./node_modules/.bin/pm2 start app.js -i max --name "cnode" --max-memory-restart 400M >> cnode.log 2>&1 &
+	@nohup ./node_modules/.bin/pm2 start app.js -i 0 --name "cnode" --max-memory-restart 400M >> cnode.log 2>&1 &
 
 restart: install build
 	@nohup ./node_modules/.bin/pm2 restart "cnode" >> cnode.log 2>&1 &


### PR DESCRIPTION
# Cluster mode
$ pm2 start app.js -i 0        # Will start maximum processes with LB depending on available CPUs
$ pm2 start app.js -i max      # Same as above, but deprecated yet.