### PR TITLE
Fixed 注册邮件发送错误：454 Command not permitted when TLS active

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -65,6 +65,7 @@ var config = {
   mail_opts: {
     host: 'smtp.126.com',
     port: 25,
+    ignoreTLS: true,
     auth: {
       user: 'club@126.com',
       pass: 'club'


### PR DESCRIPTION
作为默认的例子，最好是只改user和pass就可以设置成功。 
但是126的25端口必须配置ignoreTLS: true,才可以正确发送。
希望合并这个提交，减少新手的坑。