### PR TITLE
增加 Docker 部署支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM centos:centos7
 MAINTAINER jamiesun <jamiesun.net@gmail.com>
 
+VOLUME [ "/etc/nodeclub" ]
+
 RUN yum update -y
 RUN yum install -y epel-release
 RUN yum install -y gcc make git nodejs npm openssl openssl-devel zip unzip libjpeg-devel libpng-devel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM centos:centos7
+MAINTAINER jamiesun <jamiesun.net@gmail.com>
+
+RUN yum update -y
+RUN yum install -y epel-release
+RUN yum install -y gcc make git nodejs npm openssl openssl-devel zip unzip libjpeg-devel libpng-devel
+RUN yum clean all
+
+RUN npm install -g n && n stable
+
+RUN git clone -b master https://github.com/cnodejs/nodeclub.git /opt/nodeclub
+RUN cd /opt/nodeclub && make install && make build
+
+ADD runclub /usr/local/bin/runclub
+RUN chmod +x /usr/local/bin/runclub
+
+EXPOSE 3000
+
+CMD ["/usr/local/bin/runclub"]

--- a/runclub
+++ b/runclub
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd /opt/nodeclub
+
+git pull origin master
+
+test -f /opt/nodeclub/config.js || cp /etc/nodeclub/config.js /opt/nodeclub/config.js
+
+node app.js


### PR DESCRIPTION
在项目根目录加入了 Dockerfile 构建文件，可以通过 docker hub构建nodeclub镜像。在主机上新增配置文件 /etc/nodeclub/config.js, 运行容器 docker run -d -it -v /etc/nodeclub/config.js:/opt/nodeclub/config.js  nodeclub。部署案例 http://forum.toughcloud.net