### PR TITLE
将 pre 代码里的 tab 宽度设置为 4 个空格大小

### DIFF
--- a/public/stylesheets/common.css
+++ b/public/stylesheets/common.css
@@ -48,6 +48,9 @@ div pre.prettyprint {
     margin: 20px -10px;
     border-width: 1px 0px;
     background: #f7f7f7;
+    -o-tab-size: 4;
+    -moz-tab-size: 4;
+    tab-size: 4;
 }
 
 form {


### PR DESCRIPTION
有时用户在帖代码时使用 tab（例如：https://cnodejs.org/topic/58666e15e5c3db1339cce1fd ），浏览器默认使用 8 个空格大小来显示，这看起来过宽了，因此这里将其修改为 4 个空格大小。