### PR TITLE
修复网页点击消息不会设置消息为已读的问题

### DIFF
--- a/api/v1/message.js
+++ b/api/v1/message.js
@@ -85,7 +85,7 @@ var markOne = function (req, res, next) {
   var msg_id = req.params.msg_id;
   var ep = new eventproxy();
   ep.fail(next);
-  Message.updateMessagesToRead(msg_id, ep.done('marked_result', function (result) {
+  Message.updateMessageToRead(msg_id, ep.done('marked_result', function (result) {
     return result;
   }));
 

--- a/proxy/message.js
+++ b/proxy/message.js
@@ -107,7 +107,7 @@ exports.updateMessagesToRead = function (userId, messages, callback) {
 /**
  * 将单个消息设置成已读
  */
-exports.updateMessagesToRead = function (msg_id, callback) {
+exports.updateMessageToRead = function (msg_id, callback) {
   callback = callback || _.noop;
   if (!msg_id) {
     return callback();


### PR DESCRIPTION
非常抱歉在提交 新增单个消息标记为已读API的时候 ，因为方法名重复覆盖问题，造成网页端无法一次清除所有未读消息的问题。
非常抱歉！
经过再次测试没有相关问题出现