### PR TITLE
修复了登陆名相同引起的查看个人资料错误的BUG

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -13,7 +13,7 @@ var validator    = require('validator');
 var _            = require('lodash');
 
 exports.index = function (req, res, next) {
-  var user_id = req.params.id;
+  var user_id = req.params.user_id;
   User.getUserById(user_id, function (err, user) {
     if (err) {
       return next(err);

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -13,8 +13,8 @@ var validator    = require('validator');
 var _            = require('lodash');
 
 exports.index = function (req, res, next) {
-  var user_name = req.params.name;
-  User.getUserByLoginName(user_name, function (err, user) {
+  var user_id = req.params.id;
+  User.getUserById(user_id, function (err, user) {
     if (err) {
       return next(err);
     }

--- a/test/controllers/user.test.js
+++ b/test/controllers/user.test.js
@@ -31,7 +31,7 @@ describe('test/controllers/user.test.js', function () {
 
   describe('#index', function () {
     it('should show user index', function (done) {
-      request.get('/user/' + testUser.loginname)
+      request.get('/user/' + testUser._id)
       .expect(200, function (err, res) {
         var texts = [
           '注册时间',

--- a/views/message/message.html
+++ b/views/message/message.html
@@ -5,7 +5,7 @@
     <% } %>
     <% if(message.type == 'reply'){ %>
 		<span>
-			<a href="/user/<%= message.author.loginname %>" target='_blank'><%= message.author.loginname %></a>
+			<a href="/user/<%= message.author._id %>" target='_blank'><%= message.author.loginname %></a>
 			回复了你的话题
 			<a href="/topic/<%- message.topic._id + (message.reply ? '#' + message.reply._id : '') %>" target='_blank'><%=
         message.topic.title %></a>
@@ -13,7 +13,7 @@
     <% } %>
     <% if(message.type == 'reply2'){ %>
 		<span>
-			<a href="/user/<%= message.author.loginname %>" target='_blank'><%= message.author.loginname %></a>
+			<a href="/user/<%= message.author._id %>" target='_blank'><%= message.author.loginname %></a>
 			在话题
 			<a href="/topic/<%= message.topic._id + (message.reply ? '#' + message.reply._id : '') %>" target='_blank'><%=
         message.topic.title %></a>
@@ -22,13 +22,13 @@
     <% } %>
     <% if(message.type == 'follow'){ %>
 	<span>
-		<a href="/user/<%= message.author.loginname %>" target='_blank'><%= message.author.loginname %></a>
+		<a href="/user/<%= message.author._id %>" target='_blank'><%= message.author.loginname %></a>
 		关注了你
 	</span>
     <% } %>
     <% if (message.type == 'at'){ %>
 		<span>
-			<a href="/user/<%= message.author.loginname %>" target='_blank'><%= message.author.loginname %></a>
+			<a href="/user/<%= message.author._id %>" target='_blank'><%= message.author.loginname %></a>
 			在话题
 			<a href="/topic/<%= message.topic._id + (message.reply ? '#' + message.reply._id : '') %>" target='_blank'><%=
         message.topic.title %></a>

--- a/views/reply/reply.html
+++ b/views/reply/reply.html
@@ -6,7 +6,7 @@
       <img src="<%= proxy(reply.author.avatar_url) %>" title="<%= reply.author.loginname %>"/></a>
 
     <div class='user_info'>
-      <a class='dark reply_author' href="/user/<%= current_user._id %>"><%= reply.author.loginname %></a>
+      <a class='dark reply_author' href="/user/<%= reply.author._id %>"><%= reply.author.loginname %></a>
       <a class="reply_time" href="#<%= reply._id %>"><%= indexInCollection + 1 %>楼•<%= reply.create_at_ago()
         %></a>
       <% if(reply.author.loginname == topic.author.loginname){ %>

--- a/views/reply/reply.html
+++ b/views/reply/reply.html
@@ -2,7 +2,7 @@
   <%- reply.ups && reply.ups.length >= topic.reply_up_threshold ? 'reply_highlight' : '' %>'
     reply_id="<%= reply._id %>" reply_to_id="<%= reply.reply_id || '' %>" id="<%= reply._id %>">
   <div class='author_content'>
-    <a href="/user/<%= reply.author.loginname %>" class="user_avatar">
+    <a href="/user/<%= reply.author._id %>" class="user_avatar">
       <img src="<%= proxy(reply.author.avatar_url) %>" title="<%= reply.author.loginname %>"/></a>
 
     <div class='user_info'>

--- a/views/reply/reply.html
+++ b/views/reply/reply.html
@@ -6,7 +6,7 @@
       <img src="<%= proxy(reply.author.avatar_url) %>" title="<%= reply.author.loginname %>"/></a>
 
     <div class='user_info'>
-      <a class='dark reply_author' href="/user/<%= reply.author.loginname %>"><%= reply.author.loginname %></a>
+      <a class='dark reply_author' href="/user/<%= current_user._id %>"><%= reply.author.loginname %></a>
       <a class="reply_time" href="#<%= reply._id %>"><%= indexInCollection + 1 %>楼•<%= reply.create_at_ago()
         %></a>
       <% if(reply.author.loginname == topic.author.loginname){ %>

--- a/views/topic/abstract.html
+++ b/views/topic/abstract.html
@@ -1,6 +1,6 @@
 <div class='cell'>
 
-  <a class="user_avatar pull-left" href="/user/<%= topic.author.loginname %>">
+  <a class="user_avatar pull-left" href="/user/<%= topic.author._id %>">
     <img src="<%= proxy(topic.author.avatar_url) %>"
          title="<%= topic.author.loginname %>"
             />

--- a/views/topic/index.html
+++ b/views/topic/index.html
@@ -57,7 +57,7 @@
           发布于 <%= topic.create_at_ago() %>
         </span>
         <span>
-          作者 <a href="/user/<%= topic.author.loginname %>"><%= topic.author.loginname %></a>
+          作者 <a href="/user/<%= topic.author._id %>"><%= topic.author.loginname %></a>
         </span>
         <span>
           <%= topic.visit_count %> 次浏览

--- a/views/user/card.html
+++ b/views/user/card.html
@@ -1,9 +1,9 @@
 <div class='user_card'>
   <div>
-    <a class='user_avatar' href="/user/<%= user.loginname %>">
+    <a class='user_avatar' href="/user/<%= user._id %>">
       <img src="<%= proxy(user.avatar_url) %>" title="<%= user.loginname %>"/>
     </a>
-    <span class='user_name'><a class='dark' href="/user/<%= user.loginname %>"><%= user.loginname %></a></span>
+    <span class='user_name'><a class='dark' href="/user/<%= user._id %>"><%= user.loginname %></a></span>
 
     <div class='board clearfix'>
       <div class='floor'>

--- a/views/user/index.html
+++ b/views/user/index.html
@@ -18,7 +18,7 @@
           <span class='big'><%= user.score %></span> 积分
           <% if (user.collect_topic_count) {%>
           <li>
-            <a class='dark' href="/user/<%= user.loginname %>/collections" target='_blank'>
+            <a class='dark' href="/user/<%= user._id %>/collections" target='_blank'>
               <span class='big collect-topic-count'><%= user.collect_topic_count %></span>个话题收藏
             </a>
           </li>
@@ -88,7 +88,7 @@
     <% if (typeof(recent_topics) !== 'undefined' && recent_topics.length > 0) { %>
     <%- partial('../topic/abstract', { collection: recent_topics, as: 'topic' }) %>
     <div class='cell more'>
-      <a class='dark' href="/user/<%= user.loginname %>/topics">查看更多»</a>
+      <a class='dark' href="/user/<%= user._id %>/topics">查看更多»</a>
     </div>
     <% } else { %>
     <div class='inner'>
@@ -104,7 +104,7 @@
     <% if (typeof(recent_replies) !== 'undefined' && recent_replies.length > 0) { %>
     <%- partial('../topic/abstract', { collection: recent_replies, as: 'topic' }) %>
     <div class='cell more'>
-      <a class='dark' href="/user/<%= user.loginname %>/replies">查看更多»</a>
+      <a class='dark' href="/user/<%= user._id %>/replies">查看更多»</a>
     </div>
     <% } else { %>
     <div class='inner'>

--- a/views/user/replies.html
+++ b/views/user/replies.html
@@ -5,7 +5,7 @@
     <div class='header'>
       <ul class='breadcrumb'>
         <li><a href='/'>主页</a><span class='divider'>/</span></li>
-        <li class='active'><a href="/user/<%=user.loginname%>"><%=user.loginname%>的主页</a></li>
+        <li class='active'><a href="/user/<%=user._id%>"><%=user.loginname%>的主页</a></li>
       </ul>
     </div>
   </div>

--- a/views/user/star.html
+++ b/views/user/star.html
@@ -1,7 +1,7 @@
 <li>
   <div>
     <i class="fa fa-star"></i>
-    <a class='dark star_name' href="/user/<%= user.loginname %>"><%= user.loginname %></a>
+    <a class='dark star_name' href="/user/<%= user._id %>"><%= user.loginname %></a>
     <span class='col_fade'><%= user.follower_count %> 粉丝</span>
     <span class='col_fade'><%= user.following_count %> 关注</span>
   </div>

--- a/views/user/top.html
+++ b/views/user/top.html
@@ -1,4 +1,4 @@
 <li>
   <span class='top_score'><%= user.score %></span>
-  <span class="user_name"><a href="/user/<%= user.loginname %>"><%= user.loginname %></a></span>
+  <span class="user_name"><a href="/user/<%= user._id %>"><%= user.loginname %></a></span>
 </li>

--- a/views/user/top100_user.html
+++ b/views/user/top100_user.html
@@ -1,11 +1,11 @@
 <tr>
   <td><b><%= indexInCollection+1 %></b></td>
   <td>
-    <a class='user_avatar' href="/user/<%= user.loginname %>">
+    <a class='user_avatar' href="/user/<%= user._id %>">
       <img src="<%= proxy(user.avatar_url) %>" title="<%= user.loginname %>"/>
     </a>
     <span class='sp10'></span>
-    <a href='/user/<%= user.loginname %>'><%= user.loginname %></a></td>
+    <a href='/user/<%= user._id %>'><%= user.loginname %></a></td>
   <td><%= user.score %></td>
   <td><%= user.topic_count %></td>
   <td><%= user.reply_count %></td>

--- a/views/user/topics.html
+++ b/views/user/topics.html
@@ -5,7 +5,7 @@
     <div class='header'>
       <ul class='breadcrumb'>
         <li><a href='/'>主页</a><span class='divider'>/</span></li>
-        <li class='active'><a href="/user/<%=user.loginname%>"><%=user.loginname%>的主页</a></li>
+        <li class='active'><a href="/user/<%=user._id%>"><%=user.loginname%>的主页</a></li>
       </ul>
     </div>
   </div>

--- a/views/user/user.html
+++ b/views/user/user.html
@@ -1,9 +1,9 @@
 <div class='user'>
   <div>
-    <a href="/user/<%= user.loginname %>">
+    <a href="/user/<%= user._id %>">
       <img class='user_avatar' src="<%= proxy(user.avatar_url) %>" title="<%= user.loginname %>"/>
     </a>
-    <span class='user_name'><a class='dark' href="/user/<%= user.loginname %>"><%= user.loginname %></a></span>
+    <span class='user_name'><a class='dark' href="/user/<%= user._id %>"><%= user.loginname %></a></span>
 
     <div class='space'></div>
     <span class='col_fade'><%= user.follower_count %> 粉丝 </span>

--- a/web_router.js
+++ b/web_router.js
@@ -55,7 +55,7 @@ router.get('/reset_pass', sign.resetPass);  // 进入重置密码页面
 router.post('/reset_pass', sign.updatePass);  // 更新密码
 
 // user controller
-router.get('/user/:id', user.index); // 用户个人主页
+router.get('/user/:user_id', user.index); // 用户个人主页
 router.get('/setting', auth.userRequired, user.showSetting); // 用户个人设置页
 router.post('/setting', auth.userRequired, user.setting); // 提交个人信息设置
 router.get('/stars', user.listStars); // 显示所有达人列表页

--- a/web_router.js
+++ b/web_router.js
@@ -55,7 +55,7 @@ router.get('/reset_pass', sign.resetPass);  // 进入重置密码页面
 router.post('/reset_pass', sign.updatePass);  // 更新密码
 
 // user controller
-router.get('/user/:name', user.index); // 用户个人主页
+router.get('/user/:id', user.index); // 用户个人主页
 router.get('/setting', auth.userRequired, user.showSetting); // 用户个人设置页
 router.post('/setting', auth.userRequired, user.setting); // 提交个人信息设置
 router.get('/stars', user.listStars); // 显示所有达人列表页


### PR DESCRIPTION
1.用户资料页面由登陆名修改为用户id
2.将所有带有user链接的的loginname参数全部替换
3.修改了测试用例中的用户页面参数由登录名为用户id
