### PR TITLE
修复当 site_logo 未设置时文本不居中问题

### DIFF
--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -827,7 +827,15 @@ textarea#title {
   padding: 4px 0px 0px 20px;
   width: 120px;
   padding: 3px 20px;
-  height: 28px;
+  height: 34px;
+  line-height: 34px;
+  text-shadow: none;
+  color: #cccccc;
+  font-weight: 700;
+
+  img {
+    vertical-align: initial;   
+  }
 }
 
 .navbar .navbar-search {


### PR DESCRIPTION
当 config.site_logo = ‘’ 时默认显示 config.name, 但文本在导航栏不居中。
修复后，并增加默认样式
![image](https://user-images.githubusercontent.com/4600839/32716853-d1f73db8-c857-11e7-9ada-9a82bfa67773.png)
